### PR TITLE
Fix get path error  and remove 'read' command in Windows

### DIFF
--- a/plugin/markdown-preview.vim
+++ b/plugin/markdown-preview.vim
@@ -8,6 +8,12 @@ if !has('python')
     finish
 endif
 
+if(has("win32") || has("win64") || has("win95") || has("win16"))
+    let g:iswindows = 1
+else
+    let g:iswindows = 0
+endif
+
 " the target resource files folder
 if !exists('g:MarkDownResDir')
     let g:MarkDownCSSDir='~/.vim/MarkDownRes'
@@ -84,13 +90,17 @@ endfunction
 
 function! PreviewWithDefaultCodeStyle(args1)
     call MarkdownPreviewWithDefaultCodeStyle(a:args1)
-    !read ENTER
+    if g:iswindows == 0
+        !read ENTER
+    endif
     call ClearAll()
 endfunction
 
 function! PreviewWithCustomCodeStyle(args1, args2)
     call MarkdownPreviewWithCustomCodeStyle(a:args1, a:args2)
-    !read ENTER
+    if g:iswindows == 0
+        !read ENTER
+    endif
     call ClearAll()
 endfunction
 

--- a/pythonx/markdown_preview.py
+++ b/pythonx/markdown_preview.py
@@ -11,7 +11,7 @@ import markdown_lib
 
 def markdownPreviewWithDefaultCodeStyle():
     cssName = vim.eval("a:args1")
-    currentpath = commands.getstatusoutput("pwd")[1]
+    currentpath = os.getcwd()
 
     content = getHead(False, cssName)
     content += getBuff()


### PR DESCRIPTION
The 'pwd' command in Windows is  unrecognized and the 'read' too. 
