### PR TITLE
Remove commands module , preview pause and default ResDir changed in Windows

### DIFF
--- a/plugin/markdown-preview.vim
+++ b/plugin/markdown-preview.vim
@@ -84,13 +84,15 @@ currentpath = os.getcwd()
 try:
     os.remove(os.path.join(currentpath, 'tmp.html'))
 except Exception:
-    print ""
+    print "Delete auto create file " + currentpath + " error. Please delete it youself"
 EOF
 endfunction
 
 function! PreviewWithDefaultCodeStyle(args1)
     call MarkdownPreviewWithDefaultCodeStyle(a:args1)
-    if g:iswindows == 0
+    if g:iswindows
+        !pause
+    else
         !read ENTER
     endif
     call ClearAll()
@@ -98,7 +100,9 @@ endfunction
 
 function! PreviewWithCustomCodeStyle(args1, args2)
     call MarkdownPreviewWithCustomCodeStyle(a:args1, a:args2)
-    if g:iswindows == 0
+    if g:iswindows
+        !pause
+    else
         !read ENTER
     endif
     call ClearAll()

--- a/plugin/markdown-preview.vim
+++ b/plugin/markdown-preview.vim
@@ -79,8 +79,8 @@ endfunction
 
 function! ClearAll()
 python << EOF
-import os, commands
-currentpath = commands.getstatusoutput("pwd")[1]
+import os
+currentpath = os.getcwd()
 try:
     os.remove(os.path.join(currentpath, 'tmp.html'))
 except Exception:

--- a/pythonx/markdown_init.py
+++ b/pythonx/markdown_init.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
-import os, vim, platform, commands, shutil, sys
+import os, vim, platform, shutil, sys
 import markdown_version
 
 def init():
@@ -26,14 +26,10 @@ def init():
 
     if not os.path.isdir(DisResDir) or not os.path.isfile(os.path.join(DisResDir, markdown_version.__PLUGIN_VERSION__)):
         if os.path.isdir(DisResDir):
-            commands.getoutput('rm -rf ' + DisResDir)
+            os.rmdir(DisResDir)
             print 'updating markdown-preview plugin...'
 
-        if platform.system() == 'Windows':
-            # not test on windows
-            print commands.getoutput('xcopy /E ' + SourceResDir + ' ' + DisResDir)
-        else:
-            print commands.getoutput('cp -R ' + SourceResDir + ' ' + DisResDir)
+        shutil.copytree(SourceResDir,DisResDir)
 
         open(os.path.join(DisResDir, markdown_version.__PLUGIN_VERSION__), "w")
 

--- a/pythonx/markdown_init.py
+++ b/pythonx/markdown_init.py
@@ -8,7 +8,7 @@ def init():
         DisResDir = vim.eval('g:MarkDownResDir')
     else:
         if platform.system() == 'Windows':
-            DisResDir = os.path.join(vim.eval('$HOME'), 'vimfiles', 'MarkDownRes')
+            DisResDir = os.path.join(vim.eval('$HOME'), '.vim', 'MarkDownRes')
         elif vim.eval("has('nvim')") == '1':
             DisResDir = os.path.join(vim.eval('$HOME'),'.nvim', 'MarkDownRes')
         else:
@@ -18,7 +18,7 @@ def init():
         SourceResDir = vim.eval('g:SourceMarkDownResDir')
     else:
         if platform.system() == 'Windows':
-            SourceResDir = os.path.join(vim.eval('$HOME'), 'vimfiles', 'bundle/markdown-preview.vim/resources')
+            SourceResDir = os.path.join(vim.eval('$HOME'), '.vim', 'bundle/markdown-preview.vim/resources')
         elif vim.eval("has('nvim')") == '1':
             SourceResDir = os.path.join(vim.eval('$HOME'),'.nvim', 'bundle/markdown-preview.vim/resources')
         else:

--- a/pythonx/markdown_preview.py
+++ b/pythonx/markdown_preview.py
@@ -5,7 +5,6 @@ import vim
 import markdown_parser
 import webbrowser
 import os, platform
-import commands
 import markdown_server
 import markdown_lib
 
@@ -27,7 +26,7 @@ def markdownPreviewWithDefaultCodeStyle():
 def markdownPreviewWithCustomCodeStyle():
     cssName     = vim.eval("a:args1")
     codeName    = vim.eval("a:args2")
-    currentpath = commands.getstatusoutput("pwd")[1]
+    currentpath = os.getcwd()
 
     content = getHead(False, cssName, codeName)
     content += getBuff()
@@ -60,7 +59,7 @@ def liveMarkdownPreviewStart():
             content = getHead(True)
             content += getBuff()
             content += getBody()
-            currentpath = commands.getstatusoutput("pwd")[1]
+            currentpath = os.getcwd()
             file = open(os.path.join(currentpath, 'tmp.html'), 'w')
             file.write(content)
             file.close()

--- a/pythonx/markdown_preview.py
+++ b/pythonx/markdown_preview.py
@@ -94,7 +94,7 @@ def getHead(isLive = False, cssstyle = 'Github', codesytle = 'default'):
         cssDir = vim.eval('g:MarkDownResDir')
     else:
         if platform.system() == 'Windows':
-            cssDir = os.path.join(vim.eval('$HOME'), 'vimfiles', 'MarkDownRes')
+            cssDir = os.path.join(vim.eval('$HOME'), '.vim', 'MarkDownRes')
         elif vim.eval("has('nvim')") == '1':
             cssDir = os.path.join(vim.eval('$HOME'),'.nvim', 'MarkDownRes')
         else:


### PR DESCRIPTION
1. The commands cause errors in different platforms , use python's own method will be better
2. Add pause in Windows when preview , the tmp file will be delete with the commands replaced by os module.
3. The default folder is '~/.vim/bundle' if you use vundle in Windows .
